### PR TITLE
Run CI on self-hosted runners

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -4,20 +4,23 @@ on:
   push:
     branches: ['*']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
+        env:
+          QC_JOB_USER_ID: ${{ secrets.JOB_USER_ID }}
+          QC_API_ACCESS_TOKEN: ${{ secrets.API_ACCESS_TOKEN }}
+          QC_JOB_ORGANIZATION_ID: ${{ secrets.JOB_ORGANIZATION_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Liberate disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
 
       - name: Checkout Lean Same Branch
         id: lean-same-branch
@@ -38,13 +41,10 @@ jobs:
       - name: Move Lean
         run: mv Lean ../Lean
 
-      - uses: addnab/docker-run-action@v3
-        with:
-          image: quantconnect/lean:foundation
-          options: --workdir /__w/Lean.Brokerages.Wolverine/Lean.Brokerages.Wolverine -v /home/runner/work:/__w -e QC_JOB_USER_ID=${{ secrets.JOB_USER_ID }} -e QC_API_ACCESS_TOKEN=${{ secrets.API_ACCESS_TOKEN }} -e QC_JOB_ORGANIZATION_ID=${{ secrets.JOB_ORGANIZATION_ID }}
-          shell: bash
-          run: |
-            # Build
-            dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Wolverine.sln && \
-            # Run Tests
-            dotnet test ./QuantConnect.Wolverine.Tests/bin/Release/QuantConnect.Brokerages.Wolverine.Tests.dll
+      - name: Run build and tests
+        run: |
+          # Build
+          dotnet build /p:Configuration=Release /v:quiet /p:WarningLevel=1 QuantConnect.Wolverine.sln && \
+          # Run Tests
+          dotnet test ./QuantConnect.Wolverine.Tests/bin/Release/QuantConnect.Brokerages.Wolverine.Tests.dll
+


### PR DESCRIPTION
Mirrors QuantConnect/Lean#9540 (`c57fd18b`): build/test now runs on **self-hosted** runners inside a job-level `quantconnect/lean:foundation` container (`--cpus 12 --memory 12g`) instead of GitHub-hosted ubuntu + `addnab/docker-run-action`. Drops the disk-cleanup step and docker-run wrapper (build/test run as a normal step in the container; secrets via container `env`), and adds a `concurrency` group (cancel-in-progress). YAML validated; needs a runner to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)